### PR TITLE
feat: Add BatchExport log storage in CH via Kafka

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -133,6 +133,7 @@ batch_exports_router = projects_router.register(
     r"batch_exports", batch_exports.BatchExportViewSet, "batch_exports", ["team_id"]
 )
 batch_exports_router.register(r"runs", batch_exports.BatchExportRunViewSet, "runs", ["team_id", "batch_export_id"])
+batch_exports_router.register(r"logs", batch_exports.BatchExportRunViewSet, "logs", ["team_id", "batch_export_id"])
 
 projects_router.register(r"warehouse_table", table.TableViewSet, "warehouse_api", ["team_id"])
 

--- a/posthog/api/test/batch_exports/operations.py
+++ b/posthog/api/test/batch_exports/operations.py
@@ -76,6 +76,16 @@ def list_batch_exports_ok(client: TestClient, team_id: int):
     return response.json()
 
 
+def list_batch_exports_logs(client: TestClient, team_id: int, batch_export_id: str):
+    return client.get(f"/api/projects/{team_id}/batch_exports/{batch_export_id}/logs")
+
+
+def list_batch_exports_logs_ok(client: TestClient, team_id: int, batch_export_id: str):
+    response = list_batch_exports_logs(client, team_id, batch_export_id)
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    return response.json()
+
+
 def backfill_batch_export(client: TestClient, team_id: int, batch_export_id: str, start_at: str, end_at: str):
     return client.post(
         f"/api/projects/{team_id}/batch_exports/{batch_export_id}/backfill",

--- a/posthog/api/test/batch_exports/test_logs.py
+++ b/posthog/api/test/batch_exports/test_logs.py
@@ -1,0 +1,54 @@
+import pytest
+from django.test.client import Client as HttpClient
+from rest_framework import status
+
+from posthog.api.test.batch_exports.conftest import start_test_worker
+from posthog.api.test.batch_exports.operations import (
+    create_batch_export_ok,
+    list_batch_exports_logs,
+)
+from posthog.api.test.test_organization import create_organization
+from posthog.api.test.test_team import create_team
+from posthog.api.test.test_user import create_user
+from posthog.temporal.client import sync_connect
+
+pytestmark = [
+    pytest.mark.django_db,
+]
+
+
+def test_can_get_export_logs_for_your_organizations(client: HttpClient):
+    temporal = sync_connect()
+
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-production-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+            "batch_window_size": 3600,
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = create_organization("Test Org")
+    team = create_team(organization)
+    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+
+    with start_test_worker(temporal):
+        response = create_batch_export_ok(
+            client,
+            team.pk,
+            batch_export_data,
+        )
+
+        response = list_batch_exports_logs(client, team.pk, response["id"])
+        assert response.status_code == status.HTTP_200_OK, response.json()

--- a/posthog/clickhouse/batch_exports_logs.py
+++ b/posthog/clickhouse/batch_exports_logs.py
@@ -1,0 +1,67 @@
+from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS, kafka_engine, ttl_period
+from posthog.clickhouse.table_engines import ReplacingMergeTree
+from posthog.kafka_client.topics import KAFKA_BATCH_EXPORTS_LOGS
+from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
+
+BATCH_EXPORTS_LOGS_TABLE = "batch_exports_logs"
+BATCH_EXPORTS_LOGS_TTL_WEEKS = 1
+
+BATCH_EXPORTS_LOGS_TABLE_BASE_SQL = """
+CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
+(
+    id UUID,
+    team_id Int64,
+    batch_export_id UUID,
+    data_interval_end DateTime64(6, 'UTC'),
+    level VARCHAR,
+    type VARCHAR,
+    message VARCHAR,
+    timestamp DateTime64(6, 'UTC')
+    {extra_fields}
+) ENGINE = {engine}
+"""
+
+BATCH_EXPORTS_LOGS_TABLE_ENGINE = lambda: ReplacingMergeTree(BATCH_EXPORTS_LOGS_TABLE, ver="_timestamp")
+BATCH_EXPORTS_LOGS_TABLE_SQL = lambda: (
+    BATCH_EXPORTS_LOGS_TABLE_BASE_SQL
+    + """ORDER BY (team_id, batch_export_id, data_interval_end, timestamp)
+{ttl_period}
+SETTINGS index_granularity=512
+"""
+).format(
+    table_name=BATCH_EXPORTS_LOGS_TABLE,
+    cluster=CLICKHOUSE_CLUSTER,
+    extra_fields=KAFKA_COLUMNS,
+    engine=BATCH_EXPORTS_LOGS_TABLE_ENGINE(),
+    ttl_period=ttl_period("timestamp", BATCH_EXPORTS_LOGS_TTL_WEEKS),
+)
+
+KAFKA_BATCH_EXPORTS_LOGS_TABLE_SQL = lambda: BATCH_EXPORTS_LOGS_TABLE_BASE_SQL.format(
+    table_name="kafka_" + BATCH_EXPORTS_LOGS_TABLE,
+    cluster=CLICKHOUSE_CLUSTER,
+    engine=kafka_engine(topic=KAFKA_BATCH_EXPORTS_LOGS),
+    extra_fields="",
+)
+
+BATCH_EXPORTS_LOGS_TABLE_MV_SQL = """
+CREATE MATERIALIZED VIEW IF NOT EXISTS {table_name}_mv ON CLUSTER '{cluster}'
+TO {database}.{table_name}
+AS SELECT
+id,
+team_id,
+batch_export_id,
+data_interval_end,
+type,
+level,
+message,
+timestamp,
+_timestamp,
+_offset
+FROM {database}.kafka_{table_name}
+""".format(
+    table_name=BATCH_EXPORTS_LOGS_TABLE, cluster=CLICKHOUSE_CLUSTER, database=CLICKHOUSE_DATABASE
+)
+
+TRUNCATE_BATCH_EXPORTS_LOGS_TABLE_SQL = (
+    f"TRUNCATE TABLE IF EXISTS {BATCH_EXPORTS_LOGS_TABLE} ON CLUSTER '{CLICKHOUSE_CLUSTER}'"
+)

--- a/posthog/clickhouse/migrations/0046_batch_exports_logs.py
+++ b/posthog/clickhouse/migrations/0046_batch_exports_logs.py
@@ -1,0 +1,12 @@
+from posthog.clickhouse.batch_exports_logs import (
+    BATCH_EXPORTS_LOGS_TABLE_MV_SQL,
+    BATCH_EXPORTS_LOGS_TABLE_SQL,
+    KAFKA_BATCH_EXPORTS_LOGS_TABLE_SQL,
+)
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+operations = [
+    run_sql_with_exceptions(BATCH_EXPORTS_LOGS_TABLE_SQL()),
+    run_sql_with_exceptions(KAFKA_BATCH_EXPORTS_LOGS_TABLE_SQL()),
+    run_sql_with_exceptions(BATCH_EXPORTS_LOGS_TABLE_MV_SQL),
+]

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -3,16 +3,20 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import kafka.errors
+from django.conf import settings
 from kafka import KafkaConsumer as KC
 from kafka import KafkaProducer as KP
-from kafka.producer.future import FutureProduceResult, FutureRecordMetadata, RecordMetadata
+from kafka.producer.future import (
+    FutureProduceResult,
+    FutureRecordMetadata,
+    RecordMetadata,
+)
 from kafka.structs import TopicPartition
 from statshog.defaults.django import statsd
 from structlog import get_logger
-from django.conf import settings
+
 from posthog.client import sync_execute
 from posthog.kafka_client import helper
-
 from posthog.utils import SingletonDecorator
 
 KAFKA_PRODUCER_RETRIES = 5

--- a/posthog/kafka_client/topics.py
+++ b/posthog/kafka_client/topics.py
@@ -2,6 +2,7 @@
 
 from posthog.settings.data_stores import KAFKA_PREFIX, SUFFIX
 
+KAFKA_BATCH_EXPORTS_LOGS = f"{KAFKA_PREFIX}batch_exports_logs{SUFFIX}"
 KAFKA_EVENTS_JSON = f"{KAFKA_PREFIX}clickhouse_events_json{SUFFIX}"
 KAFKA_EVENTS_PLUGIN_INGESTION = f"{KAFKA_PREFIX}events_plugin_ingestion{SUFFIX}"
 KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW = f"{KAFKA_PREFIX}events_plugin_ingestion_overflow{SUFFIX}"

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -8,16 +8,15 @@ from uuid import uuid4
 import boto3
 import pytest
 from aiochclient import ChClient
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.test import Client as HttpClient
 from django.test import override_settings
 from temporalio.common import RetryPolicy
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
 from ee.clickhouse.materialized_columns.columns import materialize
-
-from asgiref.sync import sync_to_async
-
 from posthog.api.test.test_organization import acreate_organization
 from posthog.api.test.test_team import acreate_team
 from posthog.batch_exports.service import acreate_batch_export, afetch_batch_export_runs
@@ -267,6 +266,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(bucket_name, s3_client,
         region="us-east-1",
         prefix=prefix,
         team_id=team_id,
+        batch_export_id="1234-1234",
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
         aws_access_key_id="object_storage_root_user",


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._


---

<!-- kody-pr-summary:start -->
This pull request implements a comprehensive logging system for Batch Exports in PostHog, storing logs in ClickHouse via Kafka. The changes include:

1. **New Log Storage Infrastructure**:
   - Created a new ClickHouse table `batch_exports_logs` with Kafka integration for log storage
   - Added a new Kafka topic `KAFKA_BATCH_EXPORTS_LOGS` for log ingestion
   - Implemented a materialized view to pipe logs from Kafka to ClickHouse

2. **Log Data Model**:
   - Defined `BatchExportLogEntry` dataclass to represent log entries with fields like id, team_id, batch_export_id, timestamp, level, type, and message
   - Added `BatchExportLogLevel` enum for log levels

3. **API Endpoint**:
   - Added a new API endpoint `/batch_exports/{batch_export_id}/logs` to retrieve logs for specific batch exports
   - Implemented filtering capabilities by date range, log level, and data interval end
   - Added pagination support with limit parameter

4. **Logging Integration**:
   - Created `BatchExportLogRecord` class to extend standard log records with batch export context
   - Implemented `KafkaLoggingHandler` to send logs to Kafka topic
   - Added `setup_logging` function to configure logging for batch export workflows
   - Integrated logging setup into S3 and Snowflake batch export workflows

5. **Query Functionality**:
   - Implemented `fetch_batch_export_log_entries` function to query logs from ClickHouse with various filters
   - Added validation functions for date ranges and limit parameters

The implementation enables centralized storage and retrieval of batch export logs, improving observability and debugging capabilities for batch export operations.
<!-- kody-pr-summary:end -->

---

<!-- kody-pr-summary:start -->
Title: feat: Add BatchExport log storage in CH via Kafka

This PR introduces end-to-end logging for Batch Export workflows, persisting logs in ClickHouse via a Kafka topic, and exposing them through the API with basic filtering.

Key changes

- ClickHouse storage and Kafka ingestion
  - New Kafka topic: KAFKA_BATCH_EXPORTS_LOGS for Batch Export logs.
  - New ClickHouse tables and materialized view:
    - batch_exports_logs (ReplacingMergeTree) with a 1-week TTL.
    - kafka_batch_exports_logs (Kafka engine) and a materialized view to stream data into the main table.
  - Schema captures: id, team_id, batch_export_id, data_interval_end, level, type, message, timestamp.

- Temporal workflows logging
  - Introduced a Kafka-backed logging handler that enriches log records with Batch Export context (team_id, export type, batch_export_id, data_interval_end) and produces them to Kafka for ingestion into ClickHouse.
  - Logging is set up for both workflow and activity loggers in S3 and Snowflake batch export workflows.
  - Workflow/activity inputs extended to include batch_export_id where needed.

- API for retrieving Batch Export logs
  - New dataclass model (BatchExportLogEntry) and retrieval function (fetch_batch_export_log_entries) to read logs from ClickHouse.
  - New viewset (BatchExportLogEntryViewSet) to list logs for a given Batch Export, with support for:
    - after/before (timestamp range)
    - data_interval_end
    - level_filter
    - limit
  - Router adds a logs route under batch exports. Note: the route is currently registered to BatchExportRunViewSet.

- Query parameter validation improvements
  - Centralized validation for after/before date ranges and limit parsing, reused in listing endpoints.

- Tests
  - Updated S3 batch export test to include batch_export_id in activity inputs.

Functional impact

- Batch Export workflows (S3 and Snowflake) now emit structured logs that are persisted in ClickHouse, enabling operational visibility for specific runs.
- Consumers can retrieve logs per Batch Export via the API with common filters (time range, level, run identification via data_interval_end).
- Short retention (1 week) is applied to logs to manage storage.
<!-- kody-pr-summary:end -->