### PR TITLE
maybe?

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -133,6 +133,7 @@ def send_member_join(invitee_uuid: str, organization_id: str) -> None:
         subject=f"{invitee.first_name} joined you on PostHog",
         template_name="member_join",
         template_context={"invitee": invitee, "organization": organization},
+        use_http=True,
     )
     # Don't send this email to the new member themselves
     members_to_email = organization.members.exclude(email=invitee.email)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._


---

<!-- kody-pr-summary:start -->
This pull request modifies the email sending functionality for member join notifications in PostHog. The change adds a `use_http=True` parameter to the email sending function, which appears to switch the email delivery method to use HTTP instead of the default method. This modification affects how member join notification emails are sent to existing organization members when a new member joins.
<!-- kody-pr-summary:end -->