### PR TITLE
Kodus Test PR - 1769123224030

### DIFF
--- a/posthog/async_migrations/migrations/0010_move_old_partitions.py
+++ b/posthog/async_migrations/migrations/0010_move_old_partitions.py
@@ -1,0 +1,94 @@
+from functools import cached_property
+
+import structlog
+
+from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperationSQL
+from posthog.client import sync_execute
+from posthog.constants import AnalyticsDBMS
+from posthog.version_requirement import ServiceVersionRequirement
+from datetime import datetime
+
+logger = structlog.get_logger(__name__)
+
+
+class Migration(AsyncMigrationDefinition):
+    description = "Move partitions with data in the future or far in the past to a backup table so we can exclude this data from queries and delete it later."
+
+    depends_on = "0009_minmax_indexes_for_materialized_columns"
+    posthog_min_version = "1.43.0"
+    posthog_max_version = "1.49.99"
+
+    parameters = {
+        "OLDEST_PARTITION_TO_KEEP": ("200001", "ID of the oldest partition to keep", str),
+        "NEWEST_PARTITION_TO_KEEP": ("202308", "ID of the newest partition to keep", str),
+        "OPTIMIZE TABLE": (False, "Optimize sharded_events table after moving partitions?", bool),
+    }
+
+    service_version_requirements = [ServiceVersionRequirement(service="clickhouse", supported_version=">=22.3.0")]
+
+    def _get_partitions_to_move(self):
+        result = sync_execute(
+            f"""
+            SELECT DISTINCT partition_id FROM system.parts
+            WHERE
+                table = 'sharded_events'
+                AND (
+                    partition_id < {self.get_parameter("OLDEST_PARTITION_TO_KEEP")}
+                    OR partition_id > {self.get_parameter("NEWEST_PARTITION_TO_KEEP")}
+                )
+            ORDER BY partition_id
+        """
+        )
+
+        return [row[0] for row in result]
+
+    @cached_property
+    def operations(self):
+        now = datetime.now()
+
+        # used to prevent replica name clashes on zookeeper if we need to rollback and run again
+        suffix = f"{now.year}_{now.month}_{now.day}_{now.hour}_{now.minute}"
+
+        backup_table_name = f"events_backup_0010_move_old_partitions_{suffix}"
+        operations = [
+            AsyncMigrationOperationSQL(
+                database=AnalyticsDBMS.CLICKHOUSE,
+                sql=f"""
+                CREATE TABLE {backup_table_name}
+                AS sharded_events
+                ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{{shard}}/posthog.{backup_table_name}', '{{replica}}', _timestamp)
+                PARTITION BY toYYYYMM(timestamp)
+                ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
+                SAMPLE BY cityHash64(distinct_id)
+                SETTINGS index_granularity = 8192
+                """,
+                rollback="DROP TABLE IF EXISTS events_backup_0010_move_old_partitions",
+                per_shard=True,
+            ),
+        ]
+
+        partitions_to_move = self._get_partitions_to_move()
+
+        for partition in partitions_to_move:
+            operations.append(
+                AsyncMigrationOperationSQL(
+                    database=AnalyticsDBMS.CLICKHOUSE,
+                    sql=f"""
+                    ALTER TABLE sharded_events MOVE PARTITION '{partition}' TO TABLE {backup_table_name}
+                    """,
+                    per_shard=True,
+                ),
+            )
+
+        if self.get_parameter("OPTIMIZE_TABLE"):
+            operations.append(
+                AsyncMigrationOperationSQL(
+                    database=AnalyticsDBMS.CLICKHOUSE,
+                    sql=f"""
+                    OPTIMIZE TABLE sharded_events FINAL
+                    """,
+                    per_shard=True,
+                ),
+            )
+
+        return operations

--- a/posthog/async_migrations/migrations/0010_move_old_partitions.py
+++ b/posthog/async_migrations/migrations/0010_move_old_partitions.py
@@ -66,7 +66,7 @@ class Migration(AsyncMigrationDefinition):
                 SAMPLE BY cityHash64(distinct_id)
                 SETTINGS index_granularity = 8192
                 """,
-                rollback="DROP TABLE IF EXISTS events_backup_0010_move_old_partitions",
+                rollback=None,
                 per_shard=False,
             ),
         ]

--- a/posthog/async_migrations/migrations/0010_move_old_partitions.py
+++ b/posthog/async_migrations/migrations/0010_move_old_partitions.py
@@ -7,6 +7,7 @@ from posthog.client import sync_execute
 from posthog.constants import AnalyticsDBMS
 from posthog.version_requirement import ServiceVersionRequirement
 from datetime import datetime
+from posthog.cloud_utils import is_cloud
 
 logger = structlog.get_logger(__name__)
 
@@ -25,6 +26,9 @@ class Migration(AsyncMigrationDefinition):
     }
 
     service_version_requirements = [ServiceVersionRequirement(service="clickhouse", supported_version=">=22.3.0")]
+
+    def is_required(self) -> bool:
+        return is_cloud()
 
     def _get_partitions_to_move(self):
         result = sync_execute(

--- a/posthog/async_migrations/migrations/0011_drop_projection.py
+++ b/posthog/async_migrations/migrations/0011_drop_projection.py
@@ -1,0 +1,33 @@
+from functools import cached_property
+
+import structlog
+
+from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperationSQL
+from posthog.constants import AnalyticsDBMS
+
+logger = structlog.get_logger(__name__)
+
+
+class Migration(AsyncMigrationDefinition):
+    description = "Delete unused projection from sharded_events"
+
+    depends_on = "0010_move_old_partitions"
+    posthog_min_version = "1.43.0"
+    posthog_max_version = "1.49.99"
+
+    @cached_property
+    def operations(self):
+        operations = [
+            AsyncMigrationOperationSQL(
+                database=AnalyticsDBMS.CLICKHOUSE,
+                sql=f"""
+                ALTER TABLE sharded_events
+                DROP PROJECTION IF EXISTS fast_max_kafka_timestamp_sharded_events
+                SETTINGS mutations_sync = 2
+                """,
+                rollback=None,
+                per_shard=True,
+            ),
+        ]
+
+        return operations

--- a/posthog/async_migrations/test/test_0010_move_old_partitions.py
+++ b/posthog/async_migrations/test/test_0010_move_old_partitions.py
@@ -52,13 +52,13 @@ class Test0010MoveOldPartitions(AsyncMigrationBaseTest):
 
         self.assertTrue(
             "ALTER TABLE sharded_events MOVE PARTITION '190001' TO TABLE events_backup"
-            in MIGRATION_DEFINITION.operations[1].sql
+            in MIGRATION_DEFINITION.operations[1].sql  # type: ignore
         )
         self.assertTrue(
             "ALTER TABLE sharded_events MOVE PARTITION '202202' TO TABLE events_backup"
-            in MIGRATION_DEFINITION.operations[2].sql
+            in MIGRATION_DEFINITION.operations[2].sql  # type: ignore
         )
         self.assertTrue(
             "ALTER TABLE sharded_events MOVE PARTITION '204502' TO TABLE events_backup"
-            in MIGRATION_DEFINITION.operations[3].sql
+            in MIGRATION_DEFINITION.operations[3].sql  # type: ignore
         )

--- a/posthog/async_migrations/test/test_0010_move_old_partitions.py
+++ b/posthog/async_migrations/test/test_0010_move_old_partitions.py
@@ -1,0 +1,64 @@
+import pytest
+
+from posthog.async_migrations.runner import start_async_migration
+from posthog.async_migrations.setup import get_async_migration_definition, setup_async_migrations
+from posthog.async_migrations.test.util import AsyncMigrationBaseTest
+from posthog.models.event.util import create_event
+from posthog.models.utils import UUIDT
+
+
+pytestmark = pytest.mark.async_migrations
+
+MIGRATION_NAME = "0010_move_old_partitions"
+
+uuid1, uuid2, uuid3 = [UUIDT() for _ in range(3)]
+
+
+MIGRATION_DEFINITION = get_async_migration_definition(MIGRATION_NAME)
+
+
+def run_migration():
+    setup_async_migrations(ignore_posthog_version=True)
+    return start_async_migration(MIGRATION_NAME, ignore_posthog_version=True)
+
+
+class Test0010MoveOldPartitions(AsyncMigrationBaseTest):
+    def setUp(self):
+        MIGRATION_DEFINITION.parameters["OLDEST_PARTITION_TO_KEEP"] = ("202301", "", str)
+        MIGRATION_DEFINITION.parameters["NEWEST_PARTITION_TO_KEEP"] = ("202302", "", str)
+        MIGRATION_DEFINITION.parameters["OPTIMIZE_TABLE"] = (False, "", bool)
+
+        create_event(
+            event_uuid=uuid1, team=self.team, distinct_id="1", event="$pageview", timestamp="1900-01-02T00:00:00Z"
+        )
+        create_event(
+            event_uuid=uuid2, team=self.team, distinct_id="1", event="$pageview", timestamp="2022-02-02T00:00:00Z"
+        )
+        create_event(
+            event_uuid=uuid3, team=self.team, distinct_id="1", event="$pageview", timestamp="2045-02-02T00:00:00Z"
+        )
+
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_completes_successfully(self):
+
+        self.assertTrue(run_migration())
+
+        # create table + 3 move operations
+        self.assertEqual(len(MIGRATION_DEFINITION.operations), 4)
+
+        self.assertTrue(
+            "ALTER TABLE sharded_events MOVE PARTITION '190001' TO TABLE events_backup"
+            in MIGRATION_DEFINITION.operations[1].sql
+        )
+        self.assertTrue(
+            "ALTER TABLE sharded_events MOVE PARTITION '202202' TO TABLE events_backup"
+            in MIGRATION_DEFINITION.operations[2].sql
+        )
+        self.assertTrue(
+            "ALTER TABLE sharded_events MOVE PARTITION '204502' TO TABLE events_backup"
+            in MIGRATION_DEFINITION.operations[3].sql
+        )

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -95,10 +95,11 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
         # Every 30 minutes, send decide request counts to the main posthog instance
         sender.add_periodic_task(crontab(minute="*/30"), calculate_decide_usage.s(), name="calculate decide usage")
 
-    if is_cloud() or settings.DEMO:
-        # Reset master project data every Monday at Thursday at 5 AM UTC. Mon and Thu because doing this every day
-        # would be too hard on ClickHouse, and those days ensure most users will have data at most 3 days old.
-        sender.add_periodic_task(crontab(day_of_week="mon,thu", hour=5, minute=0), demo_reset_master_team.s())
+    # TODO: bring back when we've cleared up the projection blocking this (async migration 0011)
+    # if is_cloud() or settings.DEMO:
+    #     # Reset master project data every Monday at Thursday at 5 AM UTC. Mon and Thu because doing this every day
+    #     # would be too hard on ClickHouse, and those days ensure most users will have data at most 3 days old.
+    #     sender.add_periodic_task(crontab(day_of_week="mon,thu", hour=5, minute=0), demo_reset_master_team.s())
 
     sender.add_periodic_task(crontab(day_of_week="fri", hour=0, minute=0), clean_stale_partials.s())
 
@@ -145,17 +146,18 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
 
         sender.add_periodic_task(get_crontab("0 6 * * *"), count_teams_with_no_property_query_count.s())
 
-    if clear_clickhouse_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON):
-        sender.add_periodic_task(
-            clear_clickhouse_crontab, clickhouse_clear_removed_data.s(), name="clickhouse clear removed data"
-        )
+    # TODO: bring back when we've cleared up the projection blocking this (async migration 0011)
+    # if clear_clickhouse_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON):
+    #     sender.add_periodic_task(
+    #         clear_clickhouse_crontab, clickhouse_clear_removed_data.s(), name="clickhouse clear removed data"
+    #     )
 
-    if clear_clickhouse_deleted_person_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_DELETED_PERSON_SCHEDULE_CRON):
-        sender.add_periodic_task(
-            clear_clickhouse_deleted_person_crontab,
-            clear_clickhouse_deleted_person.s(),
-            name="clickhouse clear deleted person data",
-        )
+    # if clear_clickhouse_deleted_person_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_DELETED_PERSON_SCHEDULE_CRON):
+    #     sender.add_periodic_task(
+    #         clear_clickhouse_deleted_person_crontab,
+    #         clear_clickhouse_deleted_person.s(),
+    #         name="clickhouse clear deleted person data",
+    #     )
 
     if settings.EE_AVAILABLE:
         sender.add_periodic_task(


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces two new asynchronous migrations and temporarily disables certain Celery tasks.

**Key Changes:**

1.  **New Async Migration `0010_move_old_partitions`**: This migration is designed for ClickHouse `sharded_events` tables, primarily for cloud environments. It identifies and moves partitions containing data from the far past or future (outside a configurable date range) to a new backup table. This helps in managing data retention, excluding irrelevant data from primary queries, and preparing for potential deletion of this data.
2.  **New Async Migration `0011_drop_projection`**: This migration drops an unused ClickHouse projection named `fast_max_kafka_timestamp_sharded_events` from the `sharded_events` table, performing a cleanup operation.
3.  **Temporary Disablement of Celery Tasks**: Several periodic Celery tasks related to ClickHouse data management (`demo_reset_master_team`, `clickhouse_clear_removed_data`, `clickhouse_clear_deleted_person`) have been temporarily commented out in `posthog/celery.py`. This is a temporary measure, as indicated by comments, to address potential conflicts or blocking issues related to the projection being dropped in migration `0011`.
<!-- kody-pr-summary:end -->